### PR TITLE
Fixes #3: Adds use of props.config in constructor

### DIFF
--- a/preact-flatpickr.js
+++ b/preact-flatpickr.js
@@ -26,7 +26,7 @@ export default class Flatpickr extends Component {
     import (`flatpickr/dist/themes/${theme}.css`);
 
     this.state = {
-      config: {},
+      config: props.config && {...props.config} || {},
       instance: null,
     };
   }


### PR DESCRIPTION
If props.config exists; create a new object with the properties from props.config, instead of just creating an empty object